### PR TITLE
Remove redundant workload restore step from workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -43,9 +43,6 @@ jobs:
         with:
           global-json-file: ./global.json
 
-      - name: Workload install
-        run: dotnet workload restore
-    
       - name: Restore dependencies
         run: dotnet restore
 


### PR DESCRIPTION
The `dotnet workload restore` step was removed from the workflow as it was redundant. The dependencies are already restored in the existing restore step, making this extra step unnecessary. This change simplifies the workflow and improves its readability.